### PR TITLE
Simplify sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,7 @@ glob = "*"
 rustc-serialize = "*"
 regex = "*" # for tests only -- shouldnt be linked in otherwise
 regex_macros = "*"
-
-[dependencies.rusqlite]
-git = "https://github.com/marcusklaas/rusqlite"
-rev = "954a99d64bd7e0f7ebcdc9958c1a58369362600a"
+rusqlite = "*"
 
 [dependencies.rust-crypto]
 git = "https://github.com/dagenix/rust-crypto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "backbonzo"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Marcus Klaas <mail@marcusklaas.nl>"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ docopt = "*"
 time = "*"
 glob = "*"
 rustc-serialize = "*"
-rusqlite = "*"
 regex = "*" # for tests only -- shouldnt be linked in otherwise
 regex_macros = "*"
+
+[dependencies.rusqlite]
+git = "https://github.com/marcusklaas/rusqlite"
+rev = "954a99d64bd7e0f7ebcdc9958c1a58369362600a"
 
 [dependencies.rust-crypto]
 git = "https://github.com/dagenix/rust-crypto"

--- a/src/export.rs
+++ b/src/export.rs
@@ -47,7 +47,6 @@ pub enum BlockReference {
 
 // This is sent *after* all the blocks of a file have been transferred. It is
 // the receiver's responsibility to persist the file to the index.
-// the receiver's responsibility to persist the file to the index.
 #[derive(Show)]
 struct FileComplete {
     pub filename: String,

--- a/src/export.rs
+++ b/src/export.rs
@@ -39,18 +39,22 @@ struct FileBlock {
     pub source_byte_count: u64
 }
 
+#[derive(Show)]
+pub enum BlockReference {
+    ById(u32),
+    ByHash(String)
+}
+
 // This is sent *after* all the blocks of a file have been transferred. It is
-// the receiver's responsibility to persist the file to the index. The block
-// id list is encoded as a vector of Options. Known blocks are represented by
-// Some(id), and new blocks are represented by None as we don't known the id
-// before they are persisted to the index
+// the receiver's responsibility to persist the file to the index.
+// the receiver's responsibility to persist the file to the index.
 #[derive(Show)]
 struct FileComplete {
     pub filename: String,
     pub hash: String,
     pub last_modified: u64,
     pub directory: Directory,
-    pub block_id_list: Vec<Option<u32>>
+    pub block_reference_list: Vec<BlockReference>
 }
 
 // Manager which walks the file system and prepares files for backup. This
@@ -139,10 +143,10 @@ impl<'sender> ExportBlockSender<'sender> {
         }
         
         let mut chunks = try!(Chunks::from_path(path, self.block_size));
-        let mut block_id_list = Vec::new();
+        let mut block_reference_list = Vec::new();
         
         while let Some(slice) = chunks.next() {
-            block_id_list.push(try!(self.export_block(slice)));
+            block_reference_list.push(try!(self.export_block(slice)));
         }
         
         try!(self.sender.send(FileInstruction::Complete(FileComplete {
@@ -150,7 +154,7 @@ impl<'sender> ExportBlockSender<'sender> {
             hash: hash,
             last_modified: last_modified,
             directory: directory,
-            block_id_list: block_id_list
+            block_reference_list: block_reference_list
         })).map_err(|_| BonzoError::Other(format!("Failed sending file"))));
 
         Ok(())
@@ -159,11 +163,11 @@ impl<'sender> ExportBlockSender<'sender> {
     // Returns the id of the block when its hash is already in the database.
     // Otherwise, it compresses and encrypts a block and sends the result on
     // the channel to be processed.
-    pub fn export_block(&mut self, block: &[u8]) -> BonzoResult<Option<u32>> {
+    pub fn export_block(&mut self, block: &[u8]) -> BonzoResult<BlockReference> {
         let hash = crypto::hash_block(block);
 
         if let Some(id) = try!(self.database.block_id_from_hash(hash.as_slice())) {
-            return Ok(Some(id))
+            return Ok(BlockReference::ById(id))
         }
 
         let mut iv = Box::new([0u8; 16]);
@@ -174,11 +178,11 @@ impl<'sender> ExportBlockSender<'sender> {
         try!(self.sender.send(FileInstruction::NewBlock(FileBlock {
             bytes: processed_bytes,
             iv: iv,
-            hash: hash,
+            hash: hash.clone(),
             source_byte_count: block.len() as u64
         })).map_err(|_| BonzoError::Other(format!("Failed sending block"))));
 
-        Ok(None)
+        Ok(BlockReference::ByHash(hash))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl BackupManager {
                     summary.add_block(byte_slice, block.source_byte_count);
                 },
                 FileInstruction::Complete(file) => {
-                    let real_id_list = try!(file.block_id_list
+                    let block_id_list = try!(file.block_id_list
                         .iter()
                         .map(|&id| id.or_else(|| id_queue.pop_front()))
                         .collect::<Option<Vec<u32>>>()
@@ -172,7 +172,7 @@ impl BackupManager {
                             file.filename.as_slice(),
                             file.hash.as_slice(),
                             file.last_modified,
-                            real_id_list.as_slice()
+                            block_id_list.as_slice()
                         ));
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl BackupManager {
                         .collect::<BonzoResult<Vec<u32>>>());
 
                     // only persist file to database if it's not already there
-                    if let file_id@Some(..) = try!(self.database.file_from_hash(file.hash.as_slice())) {rt 
+                    if let file_id@Some(..) = try!(self.database.file_from_hash(file.hash.as_slice())) {
                         try!(self.database.persist_alias(
                             file.directory,
                             file_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl BackupManager {
                         .collect::<BonzoResult<Vec<u32>>>());
 
                     // only persist file to database if it's not already there
-                    if let file_id@Some(..) = try!(self.database.file_from_hash(file.hash.as_slice())) {
+                    if let file_id@Some(..) = try!(self.database.file_from_hash(file.hash.as_slice())) {rt 
                         try!(self.database.persist_alias(
                             file.directory,
                             file_id,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,9 +4,11 @@ extern crate backbonzo;
 extern crate time;
 
 use backbonzo::BonzoError;
-use std::io::TempDir;
-use std::io::fs::{File, PathExtensions, mkdir_recursive};
+use std::io::{FileAccess, FileMode, TempDir};
+use std::io::fs::{File, PathExtensions, mkdir_recursive, rename, stat, unlink};
 use std::time::duration::Duration;
+
+
 
 #[test]
 fn init() {
@@ -75,6 +77,7 @@ fn backup_no_init() {
 }
 
 #[test]
+// tests recursive behaviour, and filters for restore
 fn backup_and_restore() {
     let source_temp = TempDir::new("source").unwrap();
     let destination_temp = TempDir::new("destination").unwrap();
@@ -131,8 +134,133 @@ fn backup_and_restore() {
 
     assert!(!restore_path.join("smth_diffrent.jpg").exists());
     assert!(restore_path.join("test/welcome.txt").exists());
+
+    // TODO: check that bytes are correct!
 }
 
-// TODO: add test playing with timestamps, and one toying with removals/ renames
+#[test]
+fn renames() {
+    let source_temp = TempDir::new("rename-source").unwrap();
+    let destination_temp = TempDir::new("first-destination").unwrap();
+    let source_path = source_temp.path().clone();
+    let destination_path = destination_temp.path().clone();
+    let password = "helloworld";
+    let deadline = time::now() + Duration::minutes(10);
 
-// TODO: add tests for results
+    assert!(backbonzo::init(source_path.clone(), password.clone()).is_ok());
+
+    let first_file_name = "first";
+    let first_message   = "first message. ".as_bytes();
+    let mut first_timestamp = 0; // milliseconds since epoch; will be set later
+
+    let second_file_name = "second";
+    let second_message   = "second".as_bytes();
+    
+    let mut second_timestamp = 0;
+    let mut third_timestamp = 0;
+    
+    // create 1 file in source map
+    {
+        let file_path = source_path.join(first_file_name);
+        let mut file = File::create(&file_path).unwrap();
+        file.write(first_message).unwrap();
+        file.fsync().unwrap();
+
+        first_timestamp = stat(&file_path).unwrap().modified;
+
+        let backup_result = backbonzo::backup(
+            source_path.clone(),
+            destination_path.clone(),
+            1000000,
+            password,
+            deadline
+        );
+
+        assert!(backup_result.is_ok());
+    }
+
+    // rename file, update modified date and backup again
+    {
+        let prev_path = source_path.join(first_file_name);
+        let file_path = source_path.join(second_file_name);
+
+        rename(&prev_path, &file_path).unwrap();
+
+        let mut file = File::open_mode(&file_path, FileMode::Open, FileAccess::ReadWrite).unwrap();
+        file.write(second_message).unwrap();
+        file.fsync().unwrap();
+        
+        second_timestamp = stat(&file_path).unwrap().modified;
+
+        let backup_result = backbonzo::backup(
+            source_path.clone(),
+            destination_path.clone(),
+            1000000,
+            password,
+            deadline
+        );
+
+        assert!(backup_result.is_ok());
+    }
+
+    // rename file to first and update timestamp
+    {
+        let first_path = source_path.join(first_file_name);
+        let second_path = source_path.join(second_file_name);
+
+        rename(&second_path, &first_path).unwrap();
+        
+        third_timestamp = stat(&first_path).unwrap().modified;
+
+        let backup_result = backbonzo::backup(
+            source_path.clone(),
+            destination_path.clone(),
+            1000000,
+            password,
+            deadline
+        );
+
+        assert!(backup_result.is_ok());
+    }
+
+    // delete file
+    {
+        let first_path = source_path.join(first_file_name);
+
+        unlink(&first_path).unwrap();
+
+        let backup_result = backbonzo::backup(
+            source_path.clone(),
+            destination_path.clone(),
+            1000000,
+            password,
+            deadline
+        );
+
+        assert!(backup_result.is_ok());
+    }
+
+    // restore to second state
+    {
+        let restore_temp = TempDir::new("rename-store").unwrap();
+        let restore_path = restore_temp.path().clone();
+
+        let restore_result = backbonzo::restore(
+            restore_path.clone(),
+            destination_path.clone(),
+            password,
+            second_timestamp + 1,
+            String::from_str("**")
+        );
+
+        assert!(restore_result.is_ok());
+
+        let first_path = restore_path.join(first_file_name);
+        let second_path = restore_path.join(second_file_name);
+
+        assert!(second_path.exists());
+        assert!(! first_path.exists());
+
+        // TODO: check bytes
+    }
+}


### PR DESCRIPTION
remove the ring buffer. that only works with a single encoder thread. now we have a message queue to which potentially many encoders can send messages. since a file is encoded (read: compressed, encrypted) by a one thread and messages from a single sender are received in the order they were sent, we can guarantee that a file's blocks are received (and persisted!) before its completion message is read.