### PR TITLE
Add file names to IO errors where possible; resolve issue #31

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -256,12 +256,12 @@ impl Database {
 
         let mut buffer = Vec::new();
 
-        try!(
+        try_io!(
             File::open(&self.path)
             .and_then(|mut file| {
                 file.read_to_end(&mut buffer)
             })
-         );
+        , &self.path);
 
         Ok(buffer)
     }

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -96,18 +96,18 @@ impl<'sender, C: CryptoScheme> ExportBlockSender<'sender, C> {
             return Ok(());
         }
         
-        let hash = try!(crypto::hash_file(path));
+        let hash = try_io!(crypto::hash_file(path), path);
 
         if let Some(file_id) = try!(self.database.file_from_hash(&hash)) {
             return Ok(try!(self.database.persist_alias(directory, Some(file_id), &filename, Some(last_modified))));
         }
         
-        let mut chunks = try!(file_chunks(path, self.block_size));
+        let mut chunks = try_io!(file_chunks(path, self.block_size), path);
         let mut block_reference_list = Vec::new();
 
         // TODO: we can make this into a map, just have to implement it on chunks
         while let Some(slice) = chunks.next() {
-            let unwrapped_slice = try!(slice);
+            let unwrapped_slice = try_io!(slice, path);
             let block_reference = try!(self.export_block(unwrapped_slice));
             
             block_reference_list.push(block_reference);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,7 @@ impl<C: CryptoScheme> BackupManager<C> {
         };
 
         try!(self.database.remove_old_aliases(timestamp));
+
         try!(self.database.remove_unused_files());
 
         self.clean_unused_blocks()

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -66,6 +66,7 @@ impl RestorationSummary {
     }
 }
 
+// FIXME: this is an anti-pattern in Rust
 impl Deref for RestorationSummary {
     type Target = Summary;
 


### PR DESCRIPTION
The cleanup command would sometimes try to delete a block which was (already) gone and throw an error.